### PR TITLE
Temporal fixed to audio Media not playing

### DIFF
--- a/commands/media.js
+++ b/commands/media.js
@@ -122,7 +122,7 @@ module.exports = {
                     await sock.sendMessage(jid, {
                         audio: audioBuffer,
                         mimetype: 'audio/mpeg',
-                        ptt: true,
+                        ptt: false,
                         
                     }, { quoted: msg });
                     break;


### PR DESCRIPTION
WhatsApp new system doesn't supports some audio file extension, better switch to odd for permanent fix